### PR TITLE
Including TS types into published package

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,8 +19,10 @@
         "Android >= 4.4"
     ],
     "files": [
-        "dist"
+        "dist",
+        "types/*.d.ts"
     ],
+    "types": "types/index.d.ts",
     "scripts": {
         "start": "npx rollup -c -w",
         "build": "npm run scripts | npm run styles",


### PR DESCRIPTION
The current package on NPM is missing TS types.
I just copied `package.json` configuration from your other plugin: https://github.com/pqina/filepond-plugin-image-preview